### PR TITLE
Rename `all` to `and`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,15 @@ Inverts the result of another condition.
 
 ```javascript
 // evaluates to true if rs2032651 != AA
-q.not(q.exact('rs2032651', 'AA'));
+var query = q.not(q.exact('rs2032651', 'AA'));
 
-q({
+query({
   rs2032651: {
     genotype: 'TT'
   }
 }); // true
 
-q({
+query({
   rs2032651: {
     genotype: 'AA'
   }
@@ -122,12 +122,12 @@ q.or([
 ]);
 ```
 
-#### all(conditions...)
+#### and(conditions...)
 
 Evaluates to true if all of the given condition functions evaluate to true.
 
 ```javascript
-q.all([
+q.and([
   q.exists('rs2032652'),
   q.has('rs2032651', 'A')
 ]);

--- a/index.js
+++ b/index.js
@@ -8,9 +8,9 @@ function callFn(data) {
 
 module.exports = logic = {
   // higher-level, operates on nested conditions
-  all: function(conditions){
+  and: function(conditions){
     if (!Array.isArray(conditions) || conditions.length === 0) {
-      throw new Error('all must receive an array with conditions');
+      throw new Error('and must receive an array with conditions');
     }
     return function(data){
       return conditions.every(callFn(data));

--- a/test/and.js
+++ b/test/and.js
@@ -2,13 +2,13 @@ var gql = require('../');
 var should = require('should');
 require('mocha');
 
-describe('all()', function() {
+describe('and()', function() {
   it('should match with one true condition', function() {
     var truth = function(data) {
       should.exist(data);
       return true;
     };
-    var fn = gql.all([truth]);
+    var fn = gql.and([truth]);
     fn(123).should.equal(true);
   });
   it('should match with two true conditions', function() {
@@ -16,7 +16,7 @@ describe('all()', function() {
       should.exist(data);
       return true;
     };
-    var fn = gql.all([truth, truth]);
+    var fn = gql.and([truth, truth]);
     fn(123).should.equal(true);
   });
   it('should not match with one false condition', function() {
@@ -24,7 +24,7 @@ describe('all()', function() {
       should.exist(data);
       return false;
     };
-    var fn = gql.all([truth]);
+    var fn = gql.and([truth]);
     fn(123).should.equal(false);
   });
   it('should not match with one false and one true condition', function() {
@@ -36,7 +36,7 @@ describe('all()', function() {
       should.exist(data);
       return false;
     };
-    var fn = gql.all([truth, truth2]);
+    var fn = gql.and([truth, truth2]);
     fn(123).should.equal(false);
   });
 });


### PR DESCRIPTION
`and` makes more sense, since that’s what the genoset criteria format on SNPedia uses.

Also `and` + `or` = ♥